### PR TITLE
alignment capitalization, resizing changes, copying images

### DIFF
--- a/Rippy/AlbumData.cs
+++ b/Rippy/AlbumData.cs
@@ -104,6 +104,12 @@ namespace Rippy
             { return FormatFolderName("FLAC"); }
         }
 
+        public string FLAC16
+        {
+            get
+            { return FormatFolderName("16-bit FLAC"); }
+        }
+
         private string FormatFolderName(string format)
         {
 

--- a/Rippy/App.config
+++ b/Rippy/App.config
@@ -25,6 +25,9 @@
             <setting name="Trackers" serializeAs="String">
                 <value>https://example1.com/stuff/announce,https://example2.com/stuff2/announce</value>
             </setting>
+            <setting name="CopyImages" serializeAs="String">
+                <value>True</value>
+            </setting>
         </Rippy.Properties.Settings>
     </userSettings>
 </configuration>

--- a/Rippy/MainWindow.xaml
+++ b/Rippy/MainWindow.xaml
@@ -35,7 +35,7 @@
         </Style>
     </Window.Resources>
     <Grid Margin="0,0,0,0">
-        <Button Panel.ZIndex="3" x:Name="settingsBtn" Content="Settings ⚙️" Style="{StaticResource LinkButton}" HorizontalAlignment="Right" Margin="0,6,12,0" VerticalAlignment="Top" Width="64" Click="settingsBtn_Click" />
+        <Button Panel.ZIndex="3" x:Name="settingsBtn" Content="Settings ⚙️" Style="{StaticResource LinkButton}" HorizontalAlignment="Left" Margin="440,6,0,0" VerticalAlignment="Top" Width="64" Click="settingsBtn_Click" />
         <StackPanel Panel.ZIndex="2" Name="pnlLeftMenu" Orientation="Horizontal" HorizontalAlignment="Left" Margin="-524,0,0,0" IsEnabled="False">
             <Border BorderBrush="#444444" BorderThickness="1" Width="524" Background="#777777" >
                 <Grid>
@@ -176,6 +176,7 @@
                             </Style>
                         </TextBox.Style>
                     </TextBox>
+                    <CheckBox x:Name="copyImages" Content="Copy Images" IsChecked="{Binding CopyImages, Mode=TwoWay, Source={x:Static properties:Settings.Default}, UpdateSourceTrigger=PropertyChanged}" Height="15" VerticalAlignment="Top" Margin="10,235,-10,0" Foreground="Black" HorizontalAlignment="Left" Width="522" Background="{x:Null}" BorderBrush="Black"/>
                     <Button x:Name="saveBtn" Content="Save" HorizontalAlignment="Left" Margin="313,230,0,0" VerticalAlignment="Top" Width="75" Click="saveBtn_Click"/>
                 </Grid>
             </Border>
@@ -185,7 +186,7 @@
                 <RowDefinition Height="272*"/>
             </Grid.RowDefinitions>
             <Label Content="FLAC Folder" HorizontalAlignment="Left" Margin="10,10,0,0" Height="27" VerticalAlignment="Top" Width="75"/>
-            <TextBox Name="FlacFolderTbx" Margin="10,37,168,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=FlacFolder, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextChanged="FlacFolder_TextChanged">
+            <TextBox Name="FlacFolderTbx" Margin="10,37,168,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=FlacFolder, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextChanged="FlacFolder_TextChanged" Grid.RowSpan="2">
                 <TextBox.Style>
                     <Style TargetType="TextBox" xmlns:sys="clr-namespace:System;assembly=mscorlib">
                         <Style.Resources>
@@ -210,9 +211,9 @@
                 </TextBox.Style>
             </TextBox>
             <Button x:Name="browseBtn" Content="Browse" HorizontalAlignment="Right" Margin="0,37,93,0" VerticalAlignment="Top" Width="70" Height="23" Click="browseBtn_Click" Grid.RowSpan="2"/>
-            <Button x:Name="metadataBtn" Content="Set Metadata" HorizontalAlignment="Right" Margin="0,37,10,0" VerticalAlignment="Top" Width="78" Height="23" Click="metadataBtn_Click"/>
-            <Label Content="File Info" Margin="10,70,454,0" VerticalAlignment="Top"/>
-            <TextBox Margin="10,96,179,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=Artist, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}">
+            <Button x:Name="metadataBtn" Content="Set Metadata" HorizontalAlignment="Right" Margin="0,37,13,0" VerticalAlignment="Top" Width="75" Height="23" Click="metadataBtn_Click" Grid.RowSpan="2"/>
+            <Label Content="File Info" Margin="12,70,452,0" VerticalAlignment="Top"/>
+            <TextBox Margin="11,96,178,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=Artist, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                         <Style.Resources>
@@ -260,7 +261,7 @@
                     </Style>
                 </TextBox.Style>
             </TextBox>
-            <TextBox Margin="0,96,10,0" Height="23" VerticalAlignment="Top" Text="{Binding Medium, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="82">
+            <TextBox Margin="0,96,14,0" Height="23" VerticalAlignment="Top" Text="{Binding Medium, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="78">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                         <Style.Resources>
@@ -284,7 +285,7 @@
                     </Style>
                 </TextBox.Style>
             </TextBox>
-            <TextBox Margin="10,124,179,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=Album, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}">
+            <TextBox Margin="11,124,178,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=Album, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                         <Style.Resources>
@@ -332,7 +333,7 @@
                     </Style>
                 </TextBox.Style>
             </TextBox>
-            <TextBox Margin="0,124,10,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=Number, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="82">
+            <TextBox Margin="0,124,14,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=Number, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="78">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                         <Style.Resources>
@@ -357,7 +358,7 @@
                 </TextBox.Style>
             </TextBox>
             <Label Content="Preview" HorizontalAlignment="Left" Margin="13,147,0,0" VerticalAlignment="Top"/>
-            <TextBox Margin="10,173,10,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=MP3320, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="False">
+            <TextBox Margin="13,173,10,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=MP3320, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="False">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                         <Style.Resources>
@@ -382,12 +383,12 @@
                 </TextBox.Style>
             </TextBox>
             <Label Content="Tracker" HorizontalAlignment="Left" Margin="11,0,0,84" VerticalAlignment="Bottom" RenderTransformOrigin="0.558,2.439"/>
-            <ComboBox x:Name="trackersCobx" Margin="10,0,10,62" ItemsSource="{Binding Path=Trackers, UpdateSourceTrigger=PropertyChanged}" SelectedItem="{Binding Path=Tracker, UpdateSourceTrigger=PropertyChanged}" Height="22" VerticalAlignment="Bottom"/>
+            <ComboBox x:Name="trackersCobx" Margin="10,0,12,62" ItemsSource="{Binding Path=Trackers, UpdateSourceTrigger=PropertyChanged}" SelectedItem="{Binding Path=Tracker, UpdateSourceTrigger=PropertyChanged}" Grid.Row="1" Height="22" VerticalAlignment="Bottom"/>
             <CheckBox x:Name="mp3320Cbx" Content="MP3 320" HorizontalAlignment="Right" Margin="0,0,193,42" IsChecked="{Binding Path=MP3320, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Grid.Row="1"/>
             <CheckBox x:Name="mp3V0Cbx" Content="MP3 V0" HorizontalAlignment="Right" Margin="0,0,128,42" IsChecked="{Binding Path=MP3V0, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Grid.Row="1"/>
             <CheckBox x:Name="mp3V2Cbx" Content="MP3 V2" HorizontalAlignment="Right" Margin="0,0,63,42" IsChecked="{Binding Path=MP3V2, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Grid.Row="1"/>
             <CheckBox x:Name="flacCbx" Content="FLAC" HorizontalAlignment="Right" Margin="0,0,12,42" IsChecked="{Binding Path=FLAC, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Grid.Row="1"/>
-            <Button x:Name="createBtn" Content="Create" Margin="0,0,10,17" Click="createBtn_Click" Height="20" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="77"/>
+            <Button x:Name="createBtn" Content="Create" Margin="0,0,12,17" Click="createBtn_Click" Height="20" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="75" Grid.Row="1"/>
         </Grid>
     </Grid>
 </Window>

--- a/Rippy/MainWindow.xaml
+++ b/Rippy/MainWindow.xaml
@@ -7,6 +7,7 @@
         xmlns:properties="clr-namespace:Rippy.Properties"
         mc:Ignorable="d"
         Title="Rippy 2.0" Height="352" Width="524"
+        MinWidth="524" MinHeight="352"
         Name="mainWindow" Icon="./rippy.ico">
     <Window.Resources>
         <Storyboard x:Key="sbShowLeftMenu" >
@@ -34,7 +35,7 @@
         </Style>
     </Window.Resources>
     <Grid Margin="0,0,0,0">
-        <Button Panel.ZIndex="3" x:Name="settingsBtn" Content="Settings ⚙️" Style="{StaticResource LinkButton}" HorizontalAlignment="Left" Margin="440,6,0,0" VerticalAlignment="Top" Width="64" Click="settingsBtn_Click" />
+        <Button Panel.ZIndex="3" x:Name="settingsBtn" Content="Settings ⚙️" Style="{StaticResource LinkButton}" HorizontalAlignment="Right" Margin="0,6,12,0" VerticalAlignment="Top" Width="64" Click="settingsBtn_Click" />
         <StackPanel Panel.ZIndex="2" Name="pnlLeftMenu" Orientation="Horizontal" HorizontalAlignment="Left" Margin="-524,0,0,0" IsEnabled="False">
             <Border BorderBrush="#444444" BorderThickness="1" Width="524" Background="#777777" >
                 <Grid>
@@ -180,14 +181,17 @@
             </Border>
         </StackPanel>
         <Grid Name="MainWindowGrid">
-            <Label Content="Flac Folder" HorizontalAlignment="Left" Margin="9,6,0,0" VerticalAlignment="Top"/>
-            <TextBox Name="FlacFolderTbx" Margin="10,37,0,0" HorizontalAlignment="Left" Width="338" Height="23" VerticalAlignment="Top" Text="{Binding Path=FlacFolder, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextChanged="FlacFolder_TextChanged">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="272*"/>
+            </Grid.RowDefinitions>
+            <Label Content="FLAC Folder" HorizontalAlignment="Left" Margin="10,10,0,0" Height="27" VerticalAlignment="Top" Width="75"/>
+            <TextBox Name="FlacFolderTbx" Margin="10,37,168,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=FlacFolder, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" TextChanged="FlacFolder_TextChanged">
                 <TextBox.Style>
                     <Style TargetType="TextBox" xmlns:sys="clr-namespace:System;assembly=mscorlib">
                         <Style.Resources>
                             <VisualBrush x:Key="CueBannerBrush" AlignmentX="Left" AlignmentY="Center" Stretch="None">
                                 <VisualBrush.Visual>
-                                    <Label Content="Flac Folder" Foreground="Gray" />
+                                    <Label Content="FLAC Folder" Foreground="Gray" />
                                 </VisualBrush.Visual>
                             </VisualBrush>
                         </Style.Resources>
@@ -205,10 +209,10 @@
                     </Style>
                 </TextBox.Style>
             </TextBox>
-            <Button x:Name="browseBtn" Content="Browse" HorizontalAlignment="Left" Margin="353,37,0,0" VerticalAlignment="Top" Width="70" Height="23" Click="browseBtn_Click"/>
-            <Button x:Name="metadataBtn" Content="Set Metadata" HorizontalAlignment="Left" Margin="428,37,0,0" VerticalAlignment="Top" Width="75" Height="23" Click="metadataBtn_Click"/>
-            <Label Content="File Info" HorizontalAlignment="Left" Margin="10,65,0,0" VerticalAlignment="Top"/>
-            <TextBox Margin="10,91,0,0" HorizontalAlignment="Left" Width="327" Height="23" VerticalAlignment="Top" Text="{Binding Path=Artist, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}">
+            <Button x:Name="browseBtn" Content="Browse" HorizontalAlignment="Right" Margin="0,37,93,0" VerticalAlignment="Top" Width="70" Height="23" Click="browseBtn_Click" Grid.RowSpan="2"/>
+            <Button x:Name="metadataBtn" Content="Set Metadata" HorizontalAlignment="Right" Margin="0,37,10,0" VerticalAlignment="Top" Width="78" Height="23" Click="metadataBtn_Click"/>
+            <Label Content="File Info" Margin="10,70,454,0" VerticalAlignment="Top"/>
+            <TextBox Margin="10,96,179,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=Artist, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                         <Style.Resources>
@@ -232,7 +236,7 @@
                     </Style>
                 </TextBox.Style>
             </TextBox>
-            <TextBox Margin="342,91,0,0" HorizontalAlignment="Left" Width="78" Height="23" VerticalAlignment="Top" Text="{Binding Path=Year, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}">
+            <TextBox Margin="0,96,97,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=Year, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="78">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                         <Style.Resources>
@@ -256,7 +260,7 @@
                     </Style>
                 </TextBox.Style>
             </TextBox>
-            <TextBox Margin="425,91,0,0" HorizontalAlignment="Left" Width="78" Height="23" VerticalAlignment="Top" Text="{Binding Medium, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}">
+            <TextBox Margin="0,96,10,0" Height="23" VerticalAlignment="Top" Text="{Binding Medium, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="82">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                         <Style.Resources>
@@ -280,7 +284,7 @@
                     </Style>
                 </TextBox.Style>
             </TextBox>
-            <TextBox Margin="10,119,0,0" HorizontalAlignment="Left" Width="327" Height="23" VerticalAlignment="Top" Text="{Binding Path=Album, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}">
+            <TextBox Margin="10,124,179,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=Album, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                         <Style.Resources>
@@ -304,7 +308,7 @@
                     </Style>
                 </TextBox.Style>
             </TextBox>
-            <TextBox Margin="342,119,0,0" HorizontalAlignment="Left" Width="78" Height="23" VerticalAlignment="Top" Text="{Binding Path=Publisher, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}">
+            <TextBox Margin="0,124,97,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=Publisher, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="78">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                         <Style.Resources>
@@ -328,7 +332,7 @@
                     </Style>
                 </TextBox.Style>
             </TextBox>
-            <TextBox Margin="425,119,0,0" HorizontalAlignment="Left" Width="78" Height="23" VerticalAlignment="Top" Text="{Binding Path=Number, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}">
+            <TextBox Margin="0,124,10,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=Number, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="82">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                         <Style.Resources>
@@ -352,8 +356,8 @@
                     </Style>
                 </TextBox.Style>
             </TextBox>
-            <Label Content="Preview" HorizontalAlignment="Left" Margin="9,147,0,0" VerticalAlignment="Top"/>
-            <TextBox Margin="10,178,0,0" HorizontalAlignment="Left" Width="493" Height="23" VerticalAlignment="Top" Text="{Binding Path=MP3320, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="False">
+            <Label Content="Preview" HorizontalAlignment="Left" Margin="13,147,0,0" VerticalAlignment="Top"/>
+            <TextBox Margin="10,173,10,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=MP3320, Mode=OneWay, UpdateSourceTrigger=PropertyChanged}" IsEnabled="False">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                         <Style.Resources>
@@ -377,13 +381,13 @@
                     </Style>
                 </TextBox.Style>
             </TextBox>
-            <Label Content="Tracker" HorizontalAlignment="Left" Margin="10,206,0,0" VerticalAlignment="Top" RenderTransformOrigin="0.558,2.439"/>
-            <ComboBox x:Name="trackersCobx" HorizontalAlignment="Left" Margin="10,237,0,0" VerticalAlignment="Top" Width="494" ItemsSource="{Binding Path=Trackers, UpdateSourceTrigger=PropertyChanged}" SelectedItem="{Binding Path=Tracker, UpdateSourceTrigger=PropertyChanged}"/>
-            <CheckBox x:Name="mp3320Cbx" Content="MP3 320" HorizontalAlignment="Left" Margin="256,264,0,0" VerticalAlignment="Top" IsChecked="{Binding Path=MP3320, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"/>
-            <CheckBox x:Name="mp3V0Cbx" Content="MP3 V0" HorizontalAlignment="Left" Margin="327,264,0,0" VerticalAlignment="Top" IsChecked="{Binding Path=MP3V0, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"/>
-            <CheckBox x:Name="mp3V2Cbx" Content="MP3 V2" HorizontalAlignment="Left" Margin="392,264,0,0" VerticalAlignment="Top" IsChecked="{Binding Path=MP3V2, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"/>
-            <CheckBox x:Name="flacCbx" Content="FLAC" HorizontalAlignment="Left" Margin="457,264,0,0" VerticalAlignment="Top" IsChecked="{Binding Path=FLAC, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}"/>
-            <Button x:Name="createBtn" Content="Create" HorizontalAlignment="Left" Margin="429,284,0,0" VerticalAlignment="Top" Width="75" Click="createBtn_Click"/>
+            <Label Content="Tracker" HorizontalAlignment="Left" Margin="11,0,0,84" VerticalAlignment="Bottom" RenderTransformOrigin="0.558,2.439"/>
+            <ComboBox x:Name="trackersCobx" Margin="10,0,10,62" ItemsSource="{Binding Path=Trackers, UpdateSourceTrigger=PropertyChanged}" SelectedItem="{Binding Path=Tracker, UpdateSourceTrigger=PropertyChanged}" Height="22" VerticalAlignment="Bottom"/>
+            <CheckBox x:Name="mp3320Cbx" Content="MP3 320" HorizontalAlignment="Right" Margin="0,0,193,42" IsChecked="{Binding Path=MP3320, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Grid.Row="1"/>
+            <CheckBox x:Name="mp3V0Cbx" Content="MP3 V0" HorizontalAlignment="Right" Margin="0,0,128,42" IsChecked="{Binding Path=MP3V0, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Grid.Row="1"/>
+            <CheckBox x:Name="mp3V2Cbx" Content="MP3 V2" HorizontalAlignment="Right" Margin="0,0,63,42" IsChecked="{Binding Path=MP3V2, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Grid.Row="1"/>
+            <CheckBox x:Name="flacCbx" Content="FLAC" HorizontalAlignment="Right" Margin="0,0,12,42" IsChecked="{Binding Path=FLAC, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Grid.Row="1"/>
+            <Button x:Name="createBtn" Content="Create" Margin="0,0,10,17" Click="createBtn_Click" Height="20" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="77"/>
         </Grid>
     </Grid>
 </Window>

--- a/Rippy/MainWindow.xaml
+++ b/Rippy/MainWindow.xaml
@@ -211,8 +211,8 @@
                 </TextBox.Style>
             </TextBox>
             <Button x:Name="browseBtn" Content="Browse" HorizontalAlignment="Right" Margin="0,37,93,0" VerticalAlignment="Top" Width="70" Height="23" Click="browseBtn_Click" Grid.RowSpan="2"/>
-            <Button x:Name="metadataBtn" Content="Set Metadata" HorizontalAlignment="Right" Margin="0,37,13,0" VerticalAlignment="Top" Width="75" Height="23" Click="metadataBtn_Click" Grid.RowSpan="2"/>
-            <Label Content="File Info" Margin="12,70,452,0" VerticalAlignment="Top"/>
+            <Button x:Name="metadataBtn" Content="Set Metadata" HorizontalAlignment="Right" Margin="0,37,10,0" VerticalAlignment="Top" Width="78" Height="23" Click="metadataBtn_Click"/>
+            <Label Content="File Info" Margin="12,70,442,0" VerticalAlignment="Top"/>
             <TextBox Margin="11,96,178,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=Artist, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
@@ -261,7 +261,7 @@
                     </Style>
                 </TextBox.Style>
             </TextBox>
-            <TextBox Margin="0,96,14,0" Height="23" VerticalAlignment="Top" Text="{Binding Medium, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="78">
+            <TextBox Margin="0,96,10,0" Height="23" VerticalAlignment="Top" Text="{Binding Medium, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="82">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                         <Style.Resources>
@@ -333,7 +333,7 @@
                     </Style>
                 </TextBox.Style>
             </TextBox>
-            <TextBox Margin="0,124,14,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=Number, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="78">
+            <TextBox Margin="0,124,10,0" Height="23" VerticalAlignment="Top" Text="{Binding Path=Number, Mode=TwoWay,UpdateSourceTrigger=PropertyChanged}" HorizontalAlignment="Right" Width="82">
                 <TextBox.Style>
                     <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                         <Style.Resources>
@@ -383,12 +383,14 @@
                 </TextBox.Style>
             </TextBox>
             <Label Content="Tracker" HorizontalAlignment="Left" Margin="11,0,0,84" VerticalAlignment="Bottom" RenderTransformOrigin="0.558,2.439"/>
-            <ComboBox x:Name="trackersCobx" Margin="10,0,12,62" ItemsSource="{Binding Path=Trackers, UpdateSourceTrigger=PropertyChanged}" SelectedItem="{Binding Path=Tracker, UpdateSourceTrigger=PropertyChanged}" Grid.Row="1" Height="22" VerticalAlignment="Bottom"/>
-            <CheckBox x:Name="mp3320Cbx" Content="MP3 320" HorizontalAlignment="Right" Margin="0,0,193,42" IsChecked="{Binding Path=MP3320, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Grid.Row="1"/>
-            <CheckBox x:Name="mp3V0Cbx" Content="MP3 V0" HorizontalAlignment="Right" Margin="0,0,128,42" IsChecked="{Binding Path=MP3V0, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Grid.Row="1"/>
-            <CheckBox x:Name="mp3V2Cbx" Content="MP3 V2" HorizontalAlignment="Right" Margin="0,0,63,42" IsChecked="{Binding Path=MP3V2, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Grid.Row="1"/>
-            <CheckBox x:Name="flacCbx" Content="FLAC" HorizontalAlignment="Right" Margin="0,0,12,42" IsChecked="{Binding Path=FLAC, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Grid.Row="1"/>
-            <Button x:Name="createBtn" Content="Create" Margin="0,0,12,17" Click="createBtn_Click" Height="20" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="75" Grid.Row="1"/>
+            <ComboBox x:Name="trackersCobx" Margin="10,0,10,62" ItemsSource="{Binding Path=Trackers, UpdateSourceTrigger=PropertyChanged}" SelectedItem="{Binding Path=Tracker, UpdateSourceTrigger=PropertyChanged}" Height="22" VerticalAlignment="Bottom"/>
+            <CheckBox x:Name="mp3320Cbx" Content="MP3 320" HorizontalAlignment="Right" Margin="0,0,279,42" IsChecked="{Binding Path=MP3320, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom"/>
+            <CheckBox x:Name="mp3V0Cbx" Content="MP3 V0" HorizontalAlignment="Right" Margin="0,0,214,42" IsChecked="{Binding Path=MP3V0, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom"/>
+            <CheckBox x:Name="mp3V2Cbx" Content="MP3 V2" HorizontalAlignment="Right" Margin="0,0,149,42" IsChecked="{Binding Path=MP3V2, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom"/>
+            <CheckBox x:Name="flacCbx" Content="FLAC" HorizontalAlignment="Right" Margin="0,0,98,42" IsChecked="{Binding Path=FLAC, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom"/>
+            <Button x:Name="createBtn" Content="Create" Margin="0,0,10,17" Click="createBtn_Click" Height="20" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="77"/>
+            <CheckBox x:Name="flacCbx_Copy" Content="16bit FLAC
+" HorizontalAlignment="Right" Margin="0,0,10,42" IsChecked="{Binding Path=FLAC16, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Width="83"/>
         </Grid>
     </Grid>
 </Window>

--- a/Rippy/MainWindow.xaml.cs
+++ b/Rippy/MainWindow.xaml.cs
@@ -213,11 +213,11 @@ namespace Rippy
             _fileNumber = 0;
 
             if (MP3320)
-                if (!(ProcessDirectory(_albumData.MP3320, "-b 320", totalFiles))) return;
+                if (!(ProcessDirectory(_albumData.MP3320, "-b 320 -q 0", totalFiles))) return;
             if (MP3V0)
-                if (!(ProcessDirectory(_albumData.MP3V0, "-V 0", totalFiles))) return;
+                if (!(ProcessDirectory(_albumData.MP3V0, "-V 0 -q 0", totalFiles))) return;
             if (MP3V2)
-                if (!(ProcessDirectory(_albumData.MP3V2, "-V 2", totalFiles))) return;
+                if (!(ProcessDirectory(_albumData.MP3V2, "-V 2 -q 0", totalFiles))) return;
             if (FLAC)
                 if (!(ProcessDirectory(_albumData.FLAC, null, totalFiles))) return;
         }

--- a/Rippy/MainWindow.xaml.cs
+++ b/Rippy/MainWindow.xaml.cs
@@ -121,27 +121,6 @@ namespace Rippy
             }
         }
 
-        public static String MakeRelativePath(String fromPath, String toPath)
-        {
-            if (String.IsNullOrEmpty(fromPath)) throw new ArgumentNullException("fromPath");
-            if (String.IsNullOrEmpty(toPath)) throw new ArgumentNullException("toPath");
-
-            Uri fromUri = new Uri(fromPath);
-            Uri toUri = new Uri(toPath);
-
-            if (fromUri.Scheme != toUri.Scheme) { return toPath; } // path can't be made relative.
-
-            Uri relativeUri = fromUri.MakeRelativeUri(toUri);
-            String relativePath = Uri.UnescapeDataString(relativeUri.ToString());
-
-            if (toUri.Scheme.Equals("file", StringComparison.InvariantCultureIgnoreCase))
-            {
-                relativePath = relativePath.Replace(Path.AltDirectorySeparatorChar, Path.DirectorySeparatorChar);
-            }
-
-            return relativePath;
-        }
-
         /// <summary>
         /// 
         /// </summary>

--- a/Rippy/MainWindow.xaml.cs
+++ b/Rippy/MainWindow.xaml.cs
@@ -56,7 +56,6 @@ namespace Rippy
         public bool MP3V0 { get; set; } = true;
         public bool MP3V2 { get; set; } = false;
         public bool FLAC { get; set; } = false;
-        public bool FLAC24 { get; set; } = false;
         
         public MainWindow()
         {

--- a/Rippy/MainWindow.xaml.cs
+++ b/Rippy/MainWindow.xaml.cs
@@ -131,14 +131,19 @@ namespace Rippy
         private bool TranscodeFiles(string directory, string dbargs, int totalFiles)
         {
             var processes = new List<Process>();
-            foreach (var file in Directory.EnumerateFiles(_albumData.FlacFolder).Where(x => ".flac" == new FileInfo(x).Extension.ToLower()))
+            foreach (var file in Directory.EnumerateFiles(_albumData.FlacFolder, "*", SearchOption.AllDirectories).Where(x => ".flac" == new FileInfo(x).Extension.ToLower()))
             {
                 if (_createProgressDialog.CancellationPending)
                 {
                     return false;
                 }
                 var infile = new FileInfo(file);
-                var outfile = new FileInfo(Path.Combine(directory, infile.Name.Replace(infile.Extension, (dbargs == null) ? ".flac" : ".mp3")));
+
+                var fileUri = new Uri(_albumData.FlacFolder);
+                var folderUri = new Uri(file);
+                var fileName = folderUri.LocalPath.Replace(fileUri.LocalPath, "").Replace("/", @"\");
+
+                var outfile = new FileInfo(Path.Combine(directory + fileName.Replace(infile.Extension, (dbargs == null) ? ".flac" : ".mp3")));
                 _fileNumber++;
                 int progress = (int)(100 * ((double)_fileNumber / (double)totalFiles));
                 _createProgressDialog.ReportProgress(progress, "Transcoding Files", string.Format(System.Globalization.CultureInfo.CurrentCulture, $"Transcoding {_fileNumber} / {totalFiles}"));
@@ -195,7 +200,7 @@ namespace Rippy
 
         private void _createProgressDialog_DoWork(object sender, System.ComponentModel.DoWorkEventArgs e)
         {
-            int fileCount = Directory.EnumerateFiles(_albumData.FlacFolder).Where(x => ".flac" == new FileInfo(x).Extension.ToLower()).Count();
+            int fileCount = Directory.EnumerateFiles(_albumData.FlacFolder, "*", SearchOption.AllDirectories).Where(x => ".flac" == new FileInfo(x).Extension.ToLower()).Count();
             int totalFiles = 0;
             if (MP3320)
                 totalFiles += fileCount;
@@ -256,7 +261,7 @@ namespace Rippy
         {
             try
             {
-                var file = Directory.EnumerateFiles(folder).Where(x => x.ToLower().EndsWith("flac")).FirstOrDefault();
+                var file = Directory.EnumerateFiles(folder, "*", SearchOption.AllDirectories).Where(x => x.ToLower().EndsWith("flac")).FirstOrDefault();
                 if (file != null)
                 {
                     FlacFolderTbx.Background = Brushes.White;

--- a/Rippy/MainWindow.xaml.cs
+++ b/Rippy/MainWindow.xaml.cs
@@ -219,7 +219,7 @@ namespace Rippy
             if (FLAC)
                 if (!(ProcessDirectory(_albumData.FLAC, "-convert_to=\"FLAC\" -compression-level-8", "flac", totalFiles))) return;
             if (FLAC16)
-                if (!(ProcessDirectory(_albumData.FLAC16, "-dspeffect1=\"Resample=-frequency={qt}44100{qt}\" -dspeffect2=\"Bit Depth=-depth={qt}16{qt}\" -convert_to=\"FLAC\" -compression-level-8", "flac", totalFiles))) return;
+                if (!(ProcessDirectory(_albumData.FLAC16, "-dspeffect1=\"Bit Depth=-depth={qt}16{qt}\" -convert_to=\"FLAC\" -compression-level-8", "flac", totalFiles))) return;
         }
 
         private void _createProgressDialog_RunWorkerCompleted(object sender, System.ComponentModel.RunWorkerCompletedEventArgs e)

--- a/Rippy/Properties/Settings.Designer.cs
+++ b/Rippy/Properties/Settings.Designer.cs
@@ -82,5 +82,17 @@ namespace Rippy.Properties {
                 this["Trackers"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        public bool CopyImages {
+            get {
+                return ((bool)(this["CopyImages"]));
+            }
+            set {
+                this["CopyImages"] = value;
+            }
+        }
     }
 }

--- a/Rippy/Properties/Settings.settings
+++ b/Rippy/Properties/Settings.settings
@@ -17,5 +17,8 @@
     <Setting Name="Trackers" Type="System.String" Scope="User">
       <Value Profile="(Default)">https://example1.com/stuff/announce,https://example2.com/stuff2/announce</Value>
     </Setting>
+    <Setting Name="CopyImages" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">True</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/readme.md
+++ b/readme.md
@@ -1,7 +1,7 @@
 Rippy
 =====
 
-A GUI for converting songs from flac to MP3 and creating private torrents for pass the headphones.
+A GUI for converting songs from flac to MP3 and creating private torrents for redacted.
 
 Download the latest version from [the releases page](https://github.com/flare561/Rippy/releases/)
 


### PR DESCRIPTION
I made the controls resize with the window, set a min width for the window, and capitalized FLAC.

![image](https://user-images.githubusercontent.com/4184746/28619093-d16f9cfc-71d4-11e7-95fb-4437735cddb8.png)

It will now also copy images and nested images to the transcoded folder as well. It will successfully work with nested folders like `CD1` and `CD2`

It can now handle converting 24bit FLAC to 16bit FLAC through an additional checkbox.

the command line arguments weren't passing in `-q 0`, creating a higher quality transcode.