### PR TITLE
Add "Source Flag" 

### DIFF
--- a/Rippy/AlbumData.cs
+++ b/Rippy/AlbumData.cs
@@ -17,6 +17,7 @@ namespace Rippy
         private string _flacFolder;
         private string _medium;
         private string _tracker;
+        private string _source;
 
         public event PropertyChangedEventHandler PropertyChanged;
         
@@ -69,17 +70,31 @@ namespace Rippy
         {
             get { return Properties.Settings.Default.Trackers.Split(',').ToList(); }
         }
+        public List<string> Sources
+        {
+            get { return Properties.Settings.Default.Sources.Split(',').ToList(); }
+        }
 
         public string TrackersString
         {
             get { return Rippy.Properties.Settings.Default.Trackers; }
             set { Rippy.Properties.Settings.Default.Trackers = value; OnPropertyChanged("Trackers"); OnPropertyChanged("TrackersString"); }
         }
+        public string SourcesString
+        {
+            get { return Rippy.Properties.Settings.Default.Sources; }
+            set { Rippy.Properties.Settings.Default.Sources = value; OnPropertyChanged("Sources"); OnPropertyChanged("SourcesString"); }
+        }
 
         public string Tracker
         {
             get { return _tracker; }
             set { _tracker = value; OnPropertyChanged("Tracker"); }
+        }
+        public string Source
+        {
+            get { return _source; }
+            set { _source = value; OnPropertyChanged("Source"); }
         }
 
         public string MP3320

--- a/Rippy/App.config
+++ b/Rippy/App.config
@@ -25,6 +25,9 @@
             <setting name="Trackers" serializeAs="String">
                 <value>https://example1.com/stuff/announce,https://example2.com/stuff2/announce</value>
             </setting>
+            <setting name="Sources" serializeAs="String">
+                <value>Source1,Source2</value>
+           </setting>
             <setting name="CopyImages" serializeAs="String">
                 <value>True</value>
             </setting>

--- a/Rippy/MainWindow.xaml
+++ b/Rippy/MainWindow.xaml
@@ -150,8 +150,8 @@
                             </Style>
                         </TextBox.Style>
                     </TextBox>
-                    <Label Content="Trackers" HorizontalAlignment="Left" Margin="10,172,0,0" VerticalAlignment="Top"/>
-                    <TextBox x:Name="trackersTbx" Margin="10,203,0,0" HorizontalAlignment="Left" Width="378" Height="22" VerticalAlignment="Top" Text="{Binding TrackersString, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" TextChanged="trackersTbx_TextChanged">
+                    <Label Content="Trackers" HorizontalAlignment="Left" Margin="10,169,0,0" VerticalAlignment="Top"/>
+                    <TextBox x:Name="trackersTbx" Margin="10,195,0,0" HorizontalAlignment="Left" Width="378" Height="22" VerticalAlignment="Top" Text="{Binding TrackersString, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" TextChanged="trackersTbx_TextChanged">
                         <TextBox.ToolTip>Trackers (Separate multiple trackers with a comma)</TextBox.ToolTip>
                         <TextBox.Style>
                             <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
@@ -176,8 +176,34 @@
                             </Style>
                         </TextBox.Style>
                     </TextBox>
-                    <CheckBox x:Name="copyImages" Content="Copy Images" IsChecked="{Binding CopyImages, Mode=TwoWay, Source={x:Static properties:Settings.Default}, UpdateSourceTrigger=PropertyChanged}" Height="15" VerticalAlignment="Top" Margin="10,235,-10,0" Foreground="Black" HorizontalAlignment="Left" Width="522" Background="{x:Null}" BorderBrush="Black"/>
-                    <Button x:Name="saveBtn" Content="Save" HorizontalAlignment="Left" Margin="313,230,0,0" VerticalAlignment="Top" Width="75" Click="saveBtn_Click"/>
+                    <Label Content="Sources" HorizontalAlignment="Left" Margin="10,216,0,0" VerticalAlignment="Top"/>
+                    <TextBox x:Name="sourcesTbx" Margin="10,243,0,0" HorizontalAlignment="Left" Width="378" Height="22" VerticalAlignment="Top" Text="{Binding SourcesString, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" TextChanged="sourcesTbx_TextChanged">
+                        <TextBox.ToolTip>Trackers (Separate multiple sources with a comma)</TextBox.ToolTip>
+                        <TextBox.Style>
+                            <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
+                                <Style.Resources>
+                                    <VisualBrush x:Key="CueBannerBrush" AlignmentX="Left" AlignmentY="Center" Stretch="None" >
+                                        <VisualBrush.Visual>
+                                            <Label Content="Sources" Foreground="Gray" Background="White" Width="378" Height="23"/>
+                                        </VisualBrush.Visual>
+                                    </VisualBrush>
+                                </Style.Resources>
+                                <Style.Triggers>
+                                    <Trigger Property="Text" Value="{x:Static sys:String.Empty}">
+                                        <Setter Property="Background" Value="{StaticResource CueBannerBrush}" />
+                                    </Trigger>
+                                    <Trigger Property="Text" Value="{x:Null}">
+                                        <Setter Property="Background" Value="{StaticResource CueBannerBrush}" />
+                                    </Trigger>
+                                    <Trigger Property="IsKeyboardFocused" Value="True">
+                                        <Setter Property="Background" Value="White" />
+                                    </Trigger>
+                                </Style.Triggers>
+                            </Style>
+                        </TextBox.Style>
+                    </TextBox>
+                    <CheckBox x:Name="copyImages" Content="Copy Images" IsChecked="{Binding CopyImages, Mode=TwoWay, Source={x:Static properties:Settings.Default}, UpdateSourceTrigger=PropertyChanged}" Height="15" VerticalAlignment="Top" Margin="10,279,-10,0" Foreground="Black" HorizontalAlignment="Left" Width="522" Background="{x:Null}" BorderBrush="Black"/>
+                    <Button x:Name="saveBtn" Content="Save" HorizontalAlignment="Left" Margin="313,276,0,0" VerticalAlignment="Top" Width="75" Click="saveBtn_Click"/>
                 </Grid>
             </Border>
         </StackPanel>
@@ -382,15 +408,16 @@
                     </Style>
                 </TextBox.Style>
             </TextBox>
-            <Label Content="Tracker" HorizontalAlignment="Left" Margin="11,0,0,84" VerticalAlignment="Bottom" RenderTransformOrigin="0.558,2.439"/>
-            <ComboBox x:Name="trackersCobx" Margin="10,0,10,62" ItemsSource="{Binding Path=Trackers, UpdateSourceTrigger=PropertyChanged}" SelectedItem="{Binding Path=Tracker, UpdateSourceTrigger=PropertyChanged}" Height="22" VerticalAlignment="Bottom"/>
+            <Label Content="Tracker" HorizontalAlignment="Left" Margin="13,0,0,97" VerticalAlignment="Bottom" RenderTransformOrigin="0.558,2.439"/>
+            <ComboBox x:Name="trackersCobx" Margin="10,0,10,72" ItemsSource="{Binding Path=Trackers, UpdateSourceTrigger=PropertyChanged}" SelectedItem="{Binding Path=Tracker, UpdateSourceTrigger=PropertyChanged}" Height="22" VerticalAlignment="Bottom"/>
+            <Label Content="Source" HorizontalAlignment="Left" Margin="13,0,0,39" VerticalAlignment="Bottom" RenderTransformOrigin="0.558,2.439"/>
+            <ComboBox x:Name="sourcesCobx" Margin="62,0,365,39" ItemsSource="{Binding Path=Sources, UpdateSourceTrigger=PropertyChanged}" SelectedItem="{Binding Path=Source, UpdateSourceTrigger=PropertyChanged}" Height="22" VerticalAlignment="Bottom"/>
             <CheckBox x:Name="mp3320Cbx" Content="MP3 320" HorizontalAlignment="Right" Margin="0,0,279,42" IsChecked="{Binding Path=MP3320, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom"/>
             <CheckBox x:Name="mp3V0Cbx" Content="MP3 V0" HorizontalAlignment="Right" Margin="0,0,214,42" IsChecked="{Binding Path=MP3V0, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom"/>
             <CheckBox x:Name="mp3V2Cbx" Content="MP3 V2" HorizontalAlignment="Right" Margin="0,0,149,42" IsChecked="{Binding Path=MP3V2, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom"/>
             <CheckBox x:Name="flacCbx" Content="FLAC" HorizontalAlignment="Right" Margin="0,0,98,42" IsChecked="{Binding Path=FLAC, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom"/>
             <Button x:Name="createBtn" Content="Create" Margin="0,0,10,17" Click="createBtn_Click" Height="20" VerticalAlignment="Bottom" HorizontalAlignment="Right" Width="77"/>
-            <CheckBox x:Name="flacCbx_Copy" Content="16bit FLAC
-" HorizontalAlignment="Right" Margin="0,0,10,42" IsChecked="{Binding Path=FLAC16, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Width="83"/>
+            <CheckBox x:Name="flacCbx_Copy" Content="FLAC16" HorizontalAlignment="Right" Margin="0,0,10,42" IsChecked="{Binding Path=FLAC16, RelativeSource={RelativeSource Mode=FindAncestor, AncestorType={x:Type Window}}}" Height="15" VerticalAlignment="Bottom" Width="83"/>
         </Grid>
     </Grid>
 </Window>

--- a/Rippy/MainWindow.xaml
+++ b/Rippy/MainWindow.xaml
@@ -178,7 +178,7 @@
                     </TextBox>
                     <Label Content="Sources" HorizontalAlignment="Left" Margin="10,216,0,0" VerticalAlignment="Top"/>
                     <TextBox x:Name="sourcesTbx" Margin="10,243,0,0" HorizontalAlignment="Left" Width="378" Height="22" VerticalAlignment="Top" Text="{Binding SourcesString, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}" TextChanged="sourcesTbx_TextChanged">
-                        <TextBox.ToolTip>Trackers (Separate multiple sources with a comma)</TextBox.ToolTip>
+                        <TextBox.ToolTip>Sources (Separate multiple sources with a comma)</TextBox.ToolTip>
                         <TextBox.Style>
                             <Style xmlns:sys="clr-namespace:System;assembly=mscorlib" TargetType="{x:Type TextBox}">
                                 <Style.Resources>

--- a/Rippy/MainWindow.xaml.cs
+++ b/Rippy/MainWindow.xaml.cs
@@ -214,7 +214,7 @@ namespace Rippy
             var tc = new TorrentCreator();
             tc.Private = true;
             tc.Announces.Add(new List<string>() { _albumData.Tracker });
-            tc.AddCustomInfo(new MonoTorrent.BEncoding.BEncodedString("source"), new MonoTorrent.BEncoding.BEncodedString("PTH"));
+            tc.AddCustomInfo(new MonoTorrent.BEncoding.BEncodedString("source"), new MonoTorrent.BEncoding.BEncodedString(_albumData.Source)); // add source flag
             tc.Create(new TorrentFileSource(directory), Path.Combine(Rippy.Properties.Settings.Default.TorrentDirectory, $"{name}.torrent"));
         }
         
@@ -361,6 +361,10 @@ namespace Rippy
         private void trackersTbx_TextChanged(object sender, TextChangedEventArgs e)
         {
             trackersCobx?.GetBindingExpression(ComboBox.ItemsSourceProperty)?.UpdateSource();
+        }
+        private void sourcesTbx_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            sourcesCobx?.GetBindingExpression(ComboBox.ItemsSourceProperty)?.UpdateSource();
         }
     }
 }

--- a/Rippy/MainWindow.xaml.cs
+++ b/Rippy/MainWindow.xaml.cs
@@ -64,6 +64,7 @@ namespace Rippy
             _albumData = new AlbumData();
             DataContext = _albumData;
             _albumData.Tracker = _albumData.Trackers[0];
+            _albumData.Source = _albumData.Sources[0];
             _createProgressDialog.DoWork += _createProgressDialog_DoWork;
             _createProgressDialog.RunWorkerCompleted += _createProgressDialog_RunWorkerCompleted;
         }

--- a/Rippy/Properties/Settings.Designer.cs
+++ b/Rippy/Properties/Settings.Designer.cs
@@ -82,7 +82,22 @@ namespace Rippy.Properties {
                 this["Trackers"] = value;
             }
         }
-        
+
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("Source1,Source2")]
+        public string Sources
+        {
+            get
+            {
+                return ((string)(this["Sources"]));
+            }
+            set
+            {
+                this["Sources"] = value;
+            }
+        }
+
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("True")]


### PR DESCRIPTION
This is basically a copy of the "trackers" selector but for the source flag, some trackers including RED use it, this way you don't have to download the torrent again when you upload.

In the future this should be one single input for both "tracker" and "source" so when you select a tracker the source flag is added automatically if one was specified